### PR TITLE
DataChannel support

### DIFF
--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -75,6 +75,20 @@ function attachEvents(manager) {
     socket.id = id();
     iolog('new socket got id: ' + socket.id);
 
+    socket.emit(eventName, data)
+    {
+      socket.send(JSON.stringify(
+      {
+        "eventName": eventName,
+        "data": data
+      }),
+      function(error)
+      {
+        if(error)
+          console.log(error);
+      });
+    }
+
     rtc.sockets.push(socket);
 
     // Message received
@@ -105,16 +119,7 @@ function attachEvents(manager) {
             console.log(room[j]);
 
             var soc = rtc.getSocket(room[j]);
-            soc.send(JSON.stringify({
-              "eventName": "remove_peer_connected",
-              "data": {
-                "socketId": socket.id
-              }
-            }), function(error) {
-              if (error) {
-                console.log(error);
-              }
-            });
+            soc.emit("remove_peer_connected", {"socketId": socket.id})
           }
           break;
         }
@@ -139,43 +144,22 @@ function attachEvents(manager) {
     rtc.rooms[data.room] = roomList;
 
 
-    for (var i = 0; i < roomList.length; i++) {
+    for(var i = 0; i < roomList.length; i++)
+    {
       var id = roomList[i];
-
-      if (id == socket.id) {
-        continue;
-      } else {
-
+      if(id != socket.id)
+      {
         connectionsId.push(id);
-        var soc = rtc.getSocket(id);
 
         // inform the peers that they have a new peer
-        if (soc) {
-          soc.send(JSON.stringify({
-            "eventName": "new_peer_connected",
-            "data":{
-              "socketId": socket.id
-            }
-          }), function(error) {
-            if (error) {
-              console.log(error);
-            }
-          });
-        }
+        var soc = rtc.getSocket(id);
+        if(soc)
+          soc.emit("new_peer_connected", {"socketId": socket.id})
       }
     }
 
     // send new peer a list of all prior peers
-    socket.send(JSON.stringify({
-      "eventName": "get_peers",
-      "data": {
-        "connections": connectionsId
-      }
-    }), function(error) {
-      if (error) {
-        console.log(error);
-      }
-    });
+    socket.emit("get_peers", {"connections": connectionsId})
   });
 
   //Receive ICE candidates and send to the correct socket
@@ -183,19 +167,14 @@ function attachEvents(manager) {
     iolog('send_ice_candidate');
     var soc = rtc.getSocket(data.socketId);
 
-    if (soc) {
-      soc.send(JSON.stringify({
-        "eventName": "receive_ice_candidate",
-        "data": {
-          "label": data.label,
-          "candidate": data.candidate,
-          "socketId": socket.id
-        }
-      }), function(error) {
-        if (error) {
-          console.log(error);
-        }
-      });
+    if(soc)
+    {
+      soc.emit("receive_ice_candidate",
+      {
+        "label": data.label,
+        "candidate": data.candidate,
+        "socketId": socket.id
+      })
 
       // call the 'recieve ICE candidate' callback
       rtc.fire('receive ice candidate', rtc);
@@ -206,28 +185,14 @@ function attachEvents(manager) {
   rtc.on('create_DataChannel', function(data, socket)
   {
     iolog('create_DataChannel');
-    var soc = rtc.getSocket(data.socketId);
 
+    var soc = rtc.getSocket(data.socketId);
     if(soc)
-    {
-      soc.send(JSON.stringify(
+      soc.emit("datachannel.create",
       {
-        "eventName": "datachannel.create",
-        "data":
-        {
-          "configuration":
-          {
-            "label": data.label
-          },
-          "socketId": socket.id
-        }
-      }),
-      function(error)
-      {
-        if(error)
-          console.log(error);
-      });
-    }
+        "configuration": {"label": data.label},
+        "socketId": socket.id
+      })
 
     // call the 'create DataChannel' callback
     rtc.fire('create DataChannel', rtc);
@@ -237,26 +202,15 @@ function attachEvents(manager) {
   rtc.on('datachannel.send', function(data, socket)
   {
     iolog('datachannel.send');
-    var soc = rtc.getSocket(data.socketId);
 
+    var soc = rtc.getSocket(data.socketId);
     if(soc)
-    {
-      soc.send(JSON.stringify(
+      soc.emit("datachannel.message",
       {
-        "eventName": "datachannel.message",
-        "data":
-        {
-          "socketId": socket.id,
-          "label": data.label
-          "message": data.message
-        }
-      }),
-      function(error)
-      {
-        if(error)
-          console.log(error);
-      });
-    }
+        "socketId": socket.id,
+        "label": data.label
+        "message": data.message
+      })
 
     // call the 'create DataChannel' callback
     rtc.fire('DataChannel send', rtc);
@@ -266,25 +220,14 @@ function attachEvents(manager) {
   rtc.on('datachannel.ready', function(data, socket)
   {
     iolog('datachannel.ready');
-    var soc = rtc.getSocket(data.socketId);
 
+    var soc = rtc.getSocket(data.socketId);
     if(soc)
-    {
-      soc.send(JSON.stringify(
+      soc.emit("datachannel.ready",
       {
-        "eventName": "datachannel.ready",
-        "data":
-        {
-          "socketId": socket.id,
-          "label": data.label
-        }
-      }),
-      function(error)
-      {
-        if(error)
-          console.log(error);
-      });
-    }
+        "socketId": socket.id,
+        "label": data.label
+      })
 
     // call the 'create DataChannel' callback
     rtc.fire('DataChannel ready', rtc);
@@ -293,21 +236,14 @@ function attachEvents(manager) {
   //Receive offer and send to correct socket
   rtc.on('send_offer', function(data, socket) {
     iolog('send_offer');
-    var soc = rtc.getSocket(data.socketId);
 
-    if (soc) {
-      soc.send(JSON.stringify({
-        "eventName": "receive_offer",
-        "data": {
-          "sdp": data.sdp,
-          "socketId": socket.id
-        }
-      }), function(error) {
-        if (error) {
-          console.log(error);
-        }
-      });
-    }
+    var soc = rtc.getSocket(data.socketId);
+    if(soc)
+      soc.emit("receive_offer",
+      {
+        "sdp": data.sdp,
+        "socketId": socket.id
+      })
 
     // call the 'send offer' callback
     rtc.fire('send offer', rtc);
@@ -316,20 +252,16 @@ function attachEvents(manager) {
   //Receive answer and send to correct socket
   rtc.on('send_answer', function(data, socket) {
     iolog('send_answer');
-    var soc = rtc.getSocket( data.socketId);
 
-    if (soc) {
-      soc.send(JSON.stringify({
-        "eventName": "receive_answer",
-        "data" : {
-          "sdp": data.sdp,
-          "socketId": socket.id
-        }
-      }), function(error) {
-        if (error) {
-          console.log(error);
-        }
-      });
+    var soc = rtc.getSocket( data.socketId);
+    if(soc)
+    {
+      soc.emit("receive_answer",
+      {
+        "sdp": data.sdp,
+        "socketId": socket.id
+      })
+
       rtc.fire('send answer', rtc);
     }
   });

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -18,32 +18,36 @@ for (var i = 0; i < process.argv.length; i++) {
 if (typeof rtc === "undefined") {
   var rtc = {};
 }
+
 //Array to store connections
 rtc.sockets = [];
 
+//Array to store rooms
 rtc.rooms = {};
 
 // Holds callbacks for certain events.
 rtc._events = {};
 
+// Register the event callbacks
 rtc.on = function(eventName, callback) {
   rtc._events[eventName] = rtc._events[eventName] || [];
   rtc._events[eventName].push(callback);
 };
 
+// Fire the events
 rtc.fire = function(eventName, _) {
   var events = rtc._events[eventName];
-  var args = Array.prototype.slice.call(arguments, 1);
-
-  if (!events) {
+  if(!events)
     return;
-  }
+
+  var args = Array.prototype.slice.call(arguments, 1);
 
   for (var i = 0, len = events.length; i < len; i++) {
     events[i].apply(null, args);
   }
 };
 
+// Attach the WebSockets server to a port or an existing server
 module.exports.listen = function(server) {
   var manager;
   if (typeof server === 'number') { 
@@ -61,8 +65,10 @@ module.exports.listen = function(server) {
   return manager;
 };
 
+// Attach different events to the WebSockets manager on connection
 function attachEvents(manager) {
 
+  // Connection established, attach the events
   manager.on('connection', function(socket) {
     iolog('connect');
 
@@ -71,11 +77,14 @@ function attachEvents(manager) {
 
     rtc.sockets.push(socket);
 
+    // Message received
     socket.on('message', function(msg) {
       var json = JSON.parse(msg);
       rtc.fire(json.eventName, json.data, socket);
     });
 
+    // Peer connection closed, notify to other peers so they can close their
+    // connections to it
     socket.on('close', function() {
       iolog('close');
 
@@ -94,6 +103,7 @@ function attachEvents(manager) {
           room.splice(room.indexOf(socket.id), 1);
           for (var j = 0; j < room.length; j++) {
             console.log(room[j]);
+
             var soc = rtc.getSocket(room[j]);
             soc.send(JSON.stringify({
               "eventName": "remove_peer_connected",
@@ -109,14 +119,13 @@ function attachEvents(manager) {
           break;
         }
       }
+
       // call the disconnect callback
       rtc.fire('disconnect', rtc);
-
     });
 
     // call the connect callback
     rtc.fire('connect', rtc);
-
   });
 
   // manages the built-in room functionality
@@ -155,6 +164,7 @@ function attachEvents(manager) {
         }
       }
     }
+
     // send new peer a list of all prior peers
     socket.send(JSON.stringify({
       "eventName": "get_peers",
@@ -203,13 +213,14 @@ function attachEvents(manager) {
         "data": {
           "sdp": data.sdp,
           "socketId": socket.id
-      }
+        }
       }), function(error) {
         if (error) {
           console.log(error);
         }
       });
     }
+
     // call the 'send offer' callback
     rtc.fire('send offer', rtc);
   });
@@ -237,19 +248,16 @@ function attachEvents(manager) {
 }
 
 // generate a 4 digit hex code randomly
-
-
 function S4() {
   return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
 }
 
 // make a REALLY COMPLICATED AND RANDOM id, kudos to dennis
-
-
 function id() {
   return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
 }
 
+// Get the socket with the requested ID
 rtc.getSocket = function(id) {
   var connections = rtc.sockets;
   if (!connections) {

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -208,7 +208,7 @@ function attachEvents(manager) {
       soc.emit("datachannel.message",
       {
         "socketId": socket.id,
-        "label": data.label
+        "label": data.label,
         "message": data.message
       })
 

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -202,6 +202,37 @@ function attachEvents(manager) {
     }
   });
 
+  //Receive request to create fake DataChannel
+  rtc.on('create_DataChannel', function(data, socket)
+  {
+    iolog('create_DataChannel');
+    var soc = rtc.getSocket(data.socketId);
+
+    if(soc)
+    {
+      soc.send(JSON.stringify(
+      {
+        "eventName": "datachannel",
+        "data":
+        {
+          "configuration":
+          {
+            "label": ""
+          },
+          "socketId": socket.id
+        }
+      }),
+      function(error)
+      {
+        if(error)
+          console.log(error);
+      });
+    }
+
+    // call the 'create DataChannel' callback
+    rtc.fire('create DataChannel', rtc);
+  });
+
   //Receive offer and send to correct socket
   rtc.on('send_offer', function(data, socket) {
     iolog('send_offer');

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -262,6 +262,34 @@ function attachEvents(manager) {
     rtc.fire('DataChannel send', rtc);
   });
 
+  //Receive request to create fake DataChannel
+  rtc.on('datachannel.ready', function(data, socket)
+  {
+    iolog('datachannel.ready');
+    var soc = rtc.getSocket(data.socketId);
+
+    if(soc)
+    {
+      soc.send(JSON.stringify(
+      {
+        "eventName": "datachannel.ready",
+        "data":
+        {
+          "socketId": socket.id,
+          "label": data.label
+        }
+      }),
+      function(error)
+      {
+        if(error)
+          console.log(error);
+      });
+    }
+
+    // call the 'create DataChannel' callback
+    rtc.fire('DataChannel ready', rtc);
+  });
+
   //Receive offer and send to correct socket
   rtc.on('send_offer', function(data, socket) {
     iolog('send_offer');

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -75,7 +75,7 @@ function attachEvents(manager) {
     socket.id = id();
     iolog('new socket got id: ' + socket.id);
 
-    socket.emit(eventName, data)
+    socket.emit = function(eventName, data)
     {
       socket.send(JSON.stringify(
       {

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -217,7 +217,7 @@ function attachEvents(manager) {
         {
           "configuration":
           {
-            "label": ""
+            "label": data.label
           },
           "socketId": socket.id
         }
@@ -247,7 +247,8 @@ function attachEvents(manager) {
         "data":
         {
           "socketId": socket.id,
-          "message": data
+          "label": data.label
+          "message": data.message
         }
       }),
       function(error)

--- a/lib/webrtc.io.js
+++ b/lib/webrtc.io.js
@@ -212,7 +212,7 @@ function attachEvents(manager) {
     {
       soc.send(JSON.stringify(
       {
-        "eventName": "datachannel",
+        "eventName": "datachannel.create",
         "data":
         {
           "configuration":
@@ -231,6 +231,34 @@ function attachEvents(manager) {
 
     // call the 'create DataChannel' callback
     rtc.fire('create DataChannel', rtc);
+  });
+
+  //Receive request to create fake DataChannel
+  rtc.on('datachannel.send', function(data, socket)
+  {
+    iolog('datachannel.send');
+    var soc = rtc.getSocket(data.socketId);
+
+    if(soc)
+    {
+      soc.send(JSON.stringify(
+      {
+        "eventName": "datachannel.message",
+        "data":
+        {
+          "socketId": socket.id,
+          "message": data
+        }
+      }),
+      function(error)
+      {
+        if(error)
+          console.log(error);
+      });
+    }
+
+    // call the 'create DataChannel' callback
+    rtc.fire('DataChannel send', rtc);
   });
 
   //Receive offer and send to correct socket

--- a/package.json
+++ b/package.json
@@ -14,11 +14,27 @@
   "keywords": [
     "webrtc"
   ],
-  "author": "Ben Brittain",
+  "author": {
+    "name": "Ben Brittain",
+    "email": "ben@brittain.org"
+  },
   "contributors": [
-      { "name": "Ben Brittain", "email": "ben@brittain.org" }
-    , { "name": "Dennis Mårtensson", "email": "me@dennis.is" }
-    , { "name": "David Peter", "email": "david.a.peter@gmail.com" }
+    {
+      "name": "Ben Brittain",
+      "email": "ben@brittain.org"
+    },
+    {
+      "name": "Dennis Mårtensson",
+      "email": "me@dennis.is"
+    },
+    {
+      "name": "David Peter",
+      "email": "david.a.peter@gmail.com"
+    },
+    {
+      "name": "Jesús Leganés Combarro",
+      "email": "piranna@gmail.com"
+    }
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
Added documentation and an emit() method "a la" socket.io, but also support for a DataChannel webshim using the synchronization channel on webrtc.io-client. I couldn't be able to test it since webrtc.io and socket.io APIs are very different, but the core code is untouched.
