### PR TITLE
Use liberal and semver-correct version string for dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "git://github.com/cavedweller/webRTC.io.git"
   },
   "dependencies": {
-    "webrtc.io-client": "latest",
-    "ws": "latest"
+    "webrtc.io-client": ">= 0.0.0",
+    "ws": ">= 0.0.0"
   },
   "keywords": [
     "webrtc"


### PR DESCRIPTION
"latest" was used previously which worked in `npm install`. The reason
for that is the registry (http://registry.npmjs.org/) can deal with both
version specifications as well as tags. "latest" has a special meaning
of "latest published package" as can be seen here:

> http://registry.npmjs.org/webrtc.io/latest

However, the string "latest" is not a semver-recognised
(http://semver.org/) version specification. When `npm shrinkwrap` or
`npm ls` is used within a parent package/repository, both commands fail
as the dependencies are not met, e.g.:

```
$ npm install semver
$ semver -v '0.0.1' -r 'latest'
  [ no output, i.e., expression failed ]
$ semver -v '0.2.3' -r '>= 0.0.0'
  0.2.3
```

By using a more liberal (yet very generic) version specification, the
installed version is ensured to always be the latest available in the
registry. In addition, any semver expressions will also parse.
